### PR TITLE
Add delete action to progress card

### DIFF
--- a/components/ProgressCard.tsx
+++ b/components/ProgressCard.tsx
@@ -1,6 +1,13 @@
 import { formatDate } from "@/utils/utils"
 import { Image } from "expo-image"
-import { ScrollView, Text, View } from "react-native"
+import Ionicons from "@expo/vector-icons/Ionicons"
+import { styled } from "nativewind"
+import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native"
+
+const StyledIonicons = styled(Ionicons)
+const StyledImage = styled(Image)
+
+import { useDeleteProgressEntry } from "@/hooks/useDeleteProgressEntry"
 
 export type ProgressData = {
 	id: string
@@ -14,22 +21,32 @@ export type ProgressData = {
 }
 
 export function ProgressCard({ entry }: { entry: ProgressData }) {
-	return (
-		<View className="bg-white rounded-lg shadow-md p-4 mb-4">
-			<Text className="text-lg font-bold mb-2">{formatDate(entry.createdAt)}</Text>
+        const deleteEntry = useDeleteProgressEntry()
+
+        const handleDelete = () => {
+                Alert.alert("Delete entry", "Are you sure you want to delete this entry?", [
+                        { text: "Cancel", style: "cancel" },
+                        { text: "Delete", style: "destructive", onPress: () => deleteEntry.mutate(entry.id) },
+                ])
+        }
+
+        return (
+                <View className="relative bg-white rounded-lg shadow-md p-4 mb-4">
+                        <TouchableOpacity
+                                onPress={handleDelete}
+                                className="absolute right-2 top-2 p-1 rounded-full"
+                        >
+                                <StyledIonicons name="trash" size={20} className="text-red-600" />
+                        </TouchableOpacity>
+                        <Text className="text-lg font-bold mb-2">{formatDate(entry.createdAt)}</Text>
 			<ScrollView horizontal showsHorizontalScrollIndicator={false} className="mb-4">
-				{entry.images.map((image) => (
-					<Image
-						key={image}
-						source={{ uri: image }}
-						className="rounded-lg mr-2"
-						style={{
-							width: 50,
-							height: 50,
-							borderRadius: 6,
-						}}
-					/>
-				))}
+                                {entry.images.map((image) => (
+                                        <StyledImage
+                                                key={image}
+                                                source={{ uri: image }}
+                                                className="mr-2 h-12 w-12 rounded-lg"
+                                        />
+                                ))}
 			</ScrollView>
 			<View className="flex-row flex-wrap">
 				<View className="w-1/2 mb-2 pr-1">

--- a/components/ProgressCard.tsx
+++ b/components/ProgressCard.tsx
@@ -1,11 +1,7 @@
 import { formatDate } from "@/utils/utils"
 import { Image } from "expo-image"
 import Ionicons from "@expo/vector-icons/Ionicons"
-import { styled } from "nativewind"
 import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native"
-
-const StyledIonicons = styled(Ionicons)
-const StyledImage = styled(Image)
 
 import { useDeleteProgressEntry } from "@/hooks/useDeleteProgressEntry"
 
@@ -36,12 +32,12 @@ export function ProgressCard({ entry }: { entry: ProgressData }) {
                                 onPress={handleDelete}
                                 className="absolute right-2 top-2 p-1 rounded-full"
                         >
-                                <StyledIonicons name="trash" size={20} className="text-red-600" />
+                                <Ionicons name="trash" size={20} className="text-red-600" />
                         </TouchableOpacity>
                         <Text className="text-lg font-bold mb-2">{formatDate(entry.createdAt)}</Text>
 			<ScrollView horizontal showsHorizontalScrollIndicator={false} className="mb-4">
                                 {entry.images.map((image) => (
-                                        <StyledImage
+                                        <Image
                                                 key={image}
                                                 source={{ uri: image }}
                                                 className="mr-2 h-12 w-12 rounded-lg"


### PR DESCRIPTION
## Summary
- add delete button to progress cards
- confirm before deleting using an alert
- style delete button and preview images with nativewind

## Testing
- `npm run lint` *(fails: GET https://registry.npmjs.org/biome - 403)*
- `npm run format` *(fails: GET https://registry.npmjs.org/biome - 403)*

------
https://chatgpt.com/codex/tasks/task_e_688afe49c448832ca83e2d685bb40c19