### PR TITLE
Fix setup guard logic

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,49 +1,52 @@
 import Ionicons from "@expo/vector-icons/Ionicons"
-import { useLiveQuery } from "drizzle-orm/expo-sqlite"
 import { Tabs, useRouter } from "expo-router"
 import { type ReactNode, useEffect } from "react"
-import { db } from "."
+import { useUser } from "@/hooks/useUser"
 
 export default function TabLayout() {
-	return (
-		<Tabs screenOptions={{ headerShown: false }}>
-			<Tabs.Screen
-				name="index"
-				options={{
-					title: "Home",
-					tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
-				}}
-			/>
-			<Tabs.Screen
-				name="camera"
-				options={{
-					title: "Camera",
-					tabBarStyle: { display: "none" },
-					tabBarIcon: ({ color, size }) => <Ionicons name="camera" size={size} color={color} />,
-				}}
-			/>
-			<Tabs.Screen
-				name="statistics"
-				options={{
-					title: "Statistics",
-					tabBarIcon: ({ color, size }) => <Ionicons name="stats-chart" size={size} color={color} />,
-				}}
-			/>
-		</Tabs>
-	)
+        return (
+                <SetupGuard>
+                        <Tabs screenOptions={{ headerShown: false }}>
+                                <Tabs.Screen
+                                        name="index"
+                                        options={{
+                                                title: "Home",
+                                                tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
+                                        }}
+                                />
+                                <Tabs.Screen
+                                        name="camera"
+                                        options={{
+                                                title: "Camera",
+                                                tabBarStyle: { display: "none" },
+                                                tabBarIcon: ({ color, size }) => <Ionicons name="camera" size={size} color={color} />,
+                                        }}
+                                />
+                                <Tabs.Screen
+                                        name="statistics"
+                                        options={{
+                                                title: "Statistics",
+                                                tabBarIcon: ({ color, size }) => <Ionicons name="stats-chart" size={size} color={color} />,
+                                        }}
+                                />
+                        </Tabs>
+                </SetupGuard>
+        )
 }
 
 const SetupGuard = ({ children }: { children: ReactNode }) => {
-	const user = useLiveQuery(db.query.usersTable.findFirst())
-	const router = useRouter()
-	useEffect(() => {
-		console.log("user", user)
-		if (!user) {
-			router.replace("/(setup)/setup")
-		}
-	}, [user])
-	// if (!user.data) {
-	// 	return <Redirect href="/(setup)/setup" />
-	// }
-	return <>{children} </>
+        const { data: user, isLoading } = useUser()
+        const router = useRouter()
+
+        useEffect(() => {
+                if (!isLoading && !user) {
+                        router.replace("/(setup)/setup")
+                }
+        }, [user, isLoading])
+
+        if (isLoading) {
+                return null
+        }
+
+        return <>{children}</>
 }

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,0 +1,11 @@
+import { db } from "@/db/db"
+import { useQuery } from "@tanstack/react-query"
+
+export const useUser = () => {
+  return useQuery({
+    queryKey: ["user"],
+    queryFn: async () => {
+      return await db.query.usersTable.findFirst()
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- only redirect to setup when user is missing
- wrap tabs with SetupGuard
- add `useUser` hook

## Testing
- `npm run lint` *(fails: GET https://registry.npmjs.org/biome - 403)*
- `npm run format:check` *(fails: GET https://registry.npmjs.org/biome - 403)*


------
https://chatgpt.com/codex/tasks/task_e_688af51cb50c832c97f025667536f714